### PR TITLE
feat: 削除した座席を保持したまま座席表を再生成する機能

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,8 +36,12 @@ document.addEventListener('DOMContentLoaded', function() {
         // エラーメッセージをクリア
         hideError();
 
-        // 削除された座席をクリア
-        deletedSeats.clear();
+        // 削除された座席の行列が変更された場合のみクリア
+        const currentSeats = seatingChart.querySelectorAll('.seat');
+        const currentRows = Math.ceil(currentSeats.length / columns);
+        if (currentRows !== rows || currentSeats.length !== rows * columns) {
+            deletedSeats.clear();
+        }
 
         // 座席の総数を計算
         const totalSeats = rows * columns;


### PR DESCRIPTION
## 概要
座席表アプリに凹凸した座席配置を固定したままランダム配置を再生成する機能を追加しました。

## 変更内容
- generateSeatingChart関数から無条件のdeletedSeats.clear()を削除
- 行列サイズが変更された場合のみ削除状態をリセットするロジックを追加
- 凹凸の座席配置を維持したままランダム配置を再生成可能に

Closes #5

Generated with [Claude Code](https://claude.ai/code)