### PR TITLE
fix: 削除状態を維持するよう座席表生成ロジックを修正

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,6 +11,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     let deleteMode = false;
     let deletedSeats = new Set();
+    let previousRows = null;
+    let previousColumns = null;
 
     generateBtn.addEventListener('click', generateSeatingChart);
     deleteToggleBtn.addEventListener('click', toggleDeleteMode);
@@ -37,11 +39,15 @@ document.addEventListener('DOMContentLoaded', function() {
         hideError();
 
         // 削除された座席の行列が変更された場合のみクリア
-        const currentSeats = seatingChart.querySelectorAll('.seat');
-        const currentRows = Math.ceil(currentSeats.length / columns);
-        if (currentRows !== rows || currentSeats.length !== rows * columns) {
-            deletedSeats.clear();
+        if (previousRows !== null && previousColumns !== null) {
+            if (previousRows !== rows || previousColumns !== columns) {
+                deletedSeats.clear();
+            }
         }
+        
+        // 現在の行列サイズを保存
+        previousRows = rows;
+        previousColumns = columns;
 
         // 座席の総数を計算
         const totalSeats = rows * columns;


### PR DESCRIPTION
## 概要
座席表アプリで削除した座席の状態が、「座席表を作成」ボタンを押した際に維持されない問題を修正しました。

## 変更内容
- 前回の行数・列数を保持する変数を追加
- DOM要素から座席数を取得する代わりに、保存した前回の行列サイズと比較
- 同じサイズで「座席表を作成」ボタンを押した場合、削除状態が維持される

Closes #5

Generated with [Claude Code](https://claude.ai/code)